### PR TITLE
Add error page and reroute all login errors to it

### DIFF
--- a/login.py
+++ b/login.py
@@ -41,7 +41,6 @@ st.text("Welcome to the Annotation App. Please enter your E-Mail and PIN to cont
 email = st.text_input("E-Mail")
 unique_id = st.text_input("PIN")
 
-
 if st.button("Log in", type="primary"):
     try:
         # File missing/corrupt
@@ -71,18 +70,14 @@ if st.button("Log in", type="primary"):
 
     # Validate the email format
     if not evaluate_email(email):
-        st.error("Invalid email format. Please enter a valid academic email address.")
-        st.stop()
-    
+        st.switch_page("pages/8_error_page.py")
+
     error_message = evaluate_userID_format(unique_id)
     if error_message:
-        st.error(error_message)
-        st.stop()
+        st.switch_page("pages/8_error_page.py")
 
-    # Validate the user ID format
     if not evaluate_userID(unique_id):
-        st.error("Invalid PIN. Please try again.")
-        st.stop()
+        st.switch_page("pages/8_error_page.py")
 
     # Lookup user
     try:
@@ -91,77 +86,39 @@ if st.button("Log in", type="primary"):
         st.error(f"Error validating user credentials: {e}")
         st.stop()
 
-    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
     if user_row.empty:
-        st.write("First-time user, welcome!")
-        try:
-            today_str = datetime.now().strftime("%Y-%m-%d")
-            new_user = pd.DataFrame({
-                "e-mail": [email],
-                "userID": [unique_id],
-                "No.Papers": [0],
-                "Papers completed": [None],
-                "Paper in progress": [None],
-                "tmpstmp1": [today_str]
-            })
-
-            # Add the new user to the existing DataFrame
-            users_df = pd.concat([users_df, new_user], ignore_index=True)
-            # Save the updated DataFrame back to the file
-            users_df.to_excel(data_table, index=False)
-            st.success("Your account has been created successfully!")
-
-            # Save session state
-            st.session_state.logged_in = True
-            st.session_state["userID"] = unique_id
-            st.set_option("client.showSidebarNavigation", True)
-            sleep(1)
-            # Move on to pick papers
-            st.switch_page("pages/2_pick_paper.py")
-        except Exception as e:
-            st.error(f"Failed to create new user: {e}")
+        st.switch_page("pages/8_error_page.py")
     else:
-        # Returing user, save session state
         try:
             st.session_state.logged_in = True
             st.session_state["userID"] = unique_id
             st.success("Logged in successfully!")
 
-            # Get today's date (just the date, not time)
             today_str = datetime.now().strftime("%Y-%m-%d")
-
-            # Get row index of the user
             user_index = user_row.index[0]
-
-            # Get all timestamp columns
             timestamp_columns = [col for col in users_df.columns if col.startswith("tmpstmp")]
-
-            # Get the dates the user already has
             user_dates = users_df.loc[user_index, timestamp_columns].dropna().astype(str).tolist()
 
             if today_str not in user_dates:
-                # Find the first empty timestamp column
                 for col in timestamp_columns:
                     if pd.isna(users_df.at[user_index, col]):
                         users_df.at[user_index, col] = today_str
                         break
                 else:
-                    # If all are filled, create a new column
                     new_col = f"tmpstmp{len(timestamp_columns)+1}"
                     users_df[new_col] = None
                     users_df.at[user_index, new_col] = today_str
 
-            # Save the updated DataFrame
             users_df.to_excel(data_table, index=False)
 
             sleep(1)
             temp_file_name = user_row["Paper in progress"].values[0]
+            st.set_option("client.showSidebarNavigation", True)
+
             if not pd.isna(temp_file_name):
-                st.set_option("client.showSidebarNavigation", True)
                 st.switch_page("pages/1_resume.py")
             else:
-                st.set_option("client.showSidebarNavigation", True)
                 st.switch_page("pages/2_pick_paper.py")
+
         except Exception as e:
             st.error(f"Unexpected error during login: {e}")

--- a/pages/8_error_page.py
+++ b/pages/8_error_page.py
@@ -1,0 +1,20 @@
+import streamlit as st
+
+st.set_page_config(page_title="Log-in error")
+
+st.title("Log-in error")
+
+st.write("""
+An error has occurred with your PIN when attempting to log you in. Please verify your e-mail matches the one you registered with and your PIN is the same you received by us. Both information is available in the verification e-mail we sent you from name1@email.com after registration. Please note, YOU NEED TO HAVE REGISTERED TO HAVE A PIN, go to the registration page if you have not already done so.
+
+If you have a PIN and you try to log in again with the correct information and you still have issues please contact info@email.com using the email you used to register and the subject line “Lost PIN”. We will reach out to you help regarding recovering your PIN.
+""")
+
+col1, col2 = st.columns(2)
+
+with col1:
+    if st.button("Back to log in page"):
+        st.switch_page("login.py")
+
+with col2:
+    st.button("Go to registration page", disabled=True)


### PR DESCRIPTION
This pull request adds a dedicated error page that is displayed whenever a login attempt fails due to:

- Invalid email format
- Incorrect PIN format
- Non-existent user (email + PIN combo)

The following updates are included:
- New file: `pages/8_error_page.py`
- Modified `login.py` to redirect all login errors to the error page
- Error page layout and text follow the Balsamiq design