### PR TITLE
Fixing experiment table and sessions table SessionID mismatch

### DIFF
--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -22,6 +22,30 @@ router.get('/by_user_pmid', async (req, res) => {
   }
 });
 
+// Get SessionID by userKey and pmid, where SessionStatus is 'open' or 'negative'
+router.get('/session_id_by_user_pmid', async (req, res) => {
+  const { userKey, pmid } = req.query;
+  if (!userKey || !pmid) {
+    return res.status(400).json({ error: "userKey and pmid are required" });
+  }
+  try {
+    const session = await SessionState.findOne({
+      where: {
+        userID: userKey,
+        PMID: pmid,
+        SessionStatus: ["open", "negative"]
+      }
+    });
+    if (session) {
+      res.json({ SessionID: session.SessionID });
+    } else {
+      res.status(404).json({ error: "Session not found" });
+    }
+  } catch (err) {
+    res.status(500).json({ error: "Database error" });
+  }
+});
+
 // Get session by SessionID
 router.get('/:id', async (req, res) => {
   try {

--- a/frontend/src/database.py
+++ b/frontend/src/database.py
@@ -280,12 +280,33 @@ def fetch_fulltext_by_pmid(pmid, token):
 
 # -- Annotation saving functions --
 
+def get_session_id(user_key, pmid, token):
+    """
+    Query the backend for the open or negative session and return only the SessionID.
+    """
+    try:
+        resp = requests.get(
+            f"{BACKEND_URL}/sessions/session_id_by_user_pmid",
+            params={"userKey": user_key, "pmid": pmid},
+            cookies={"token": token},
+            timeout=10
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            return data.get("SessionID")
+    except Exception:
+        pass
+    return None
+
 def save_annotations_to_db(session_state, user_key, pmid, token):
     """
     Save all annotated information from session_state to the backend tables.
     """
-
-    session_id = f"{user_key}_{pmid}"
+    # Fetch correct SessionID from backend
+    session_id = get_session_id(user_key, pmid, token)
+    if not session_id:
+        # Fallback mechanism
+        session_id = session_state.get("SessionID") or f"{user_key}_{pmid}"
 
     # 1. Gather all experiments and solutions
     experiments = []


### PR DESCRIPTION
Closes #155 

TODO: Mark papers negative in the sessionstatus field in the sessions table whenever the user has entered the specific answers in the question cascade.  Additionally, not just having a "negative" status, but having "negative-open" and "negative-closed" so that it is possible to track progress better for negative papers and reduce bugs.  